### PR TITLE
fix consistent configuration bug: falsy value (0, false) cannot be identified

### DIFF
--- a/lib/beans/support/placeHolderResolver.js
+++ b/lib/beans/support/placeHolderResolver.js
@@ -44,7 +44,7 @@ PlaceHolderResolver.prototype.resolveStringValue = function(strVal) {
 
 	var resolvedValue = this.doReplace(strVal);
 
-	if (!resolvedValue || !Utils.isNotNull(resolvedValue)) {
+	if (!Utils.isNotNull(resolvedValue)) {
 		resolvedValue = strVal;
 	}
 


### PR DESCRIPTION
When using placeholder in consistent configuration, falsy value cannot be replaced. For example:
in js file, you declare a car bean:
var Car = function() {
    this.isBroken = null;
}
module.exports = {
    id : 'car',
    func : Car,
    props : [{
        name : 'isBroken',
        value : '${car.broken}‘
    }]
}

When you put car.broken into false, your isBroken will be ${car.broken}.
