### PR TITLE
fix-bug:getBeanByMeta donnot post process

### DIFF
--- a/lib/context/applicationContext.js
+++ b/lib/context/applicationContext.js
@@ -529,6 +529,7 @@ ApplicationContext.prototype.getBeanByMeta = function(meta) {
 
 	this.registerBeanMeta(meta);
 
+	this.invokeBeanFactoryPostProcessors();
 	arguments = Array.prototype.slice.apply(arguments);
 	arguments[0] = id;
 	return this.beanFactory.getBeanProxy.apply(this.beanFactory, arguments);


### PR DESCRIPTION
getBeanByMeta do not call invokeBeanFactoryPostProcessors, so if use meta object as the argument in getBean, the placeHolder in meta object won't be recognized.
